### PR TITLE
[NEW] Adds footer and omits date if unspecified

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,16 @@ The following can be set either as variables when executing `pandoc` or added to
 :   Amount for closing signature block to be intended from left margin.
 
 `date`
-:   Custom date (current date will be automatically inserted if not specified).
+:   Custom date (will be omitted if `false` or not specified; for current date, use `\today`).
 
 `encl`
 :   List of enclosures.
 
 `letterhead`
 :   Image file to be used as letterhead (requires the [wallpaper][] package), applied only to the first page.
+
+`footer`
+:   Image file to be used as footer (requires the [wallpaper][] package), applied only to the first page.
 
 `opening`
 :   Text for the salutation.

--- a/template-letter.tex
+++ b/template-letter.tex
@@ -204,6 +204,8 @@ $endif$
 
 $if(date)$
 \date{$date$}
+$else$
+\date{}
 $endif$
 
 $for(header-includes)$
@@ -256,6 +258,11 @@ $endif$
 $if(letterhead)$
 \usepackage{wallpaper}
 \ThisULCornerWallPaper{1}{$letterhead$}
+$endif$
+
+$if(footer)$
+\usepackage{wallpaper}
+\ThisLLCornerWallPaper{1}{$footer$}
 $endif$
 
 \begin{document}


### PR DESCRIPTION
Two new (short) features:
* Allows a PDF footer, just like the letterhead
* Omits date if false, or not specified (for current date, use `\today`)
